### PR TITLE
Artikel einbinden: Backend- u Frontend-Ausgabe trennen

### DIFF
--- a/modul_minibeispiel_artikel_einbinden.md
+++ b/modul_minibeispiel_artikel_einbinden.md
@@ -9,54 +9,75 @@ Dadurch kann der Redakteur leicht erkennen, dass es sich um einen eingebundenen 
 Die Abfrage ob wir uns im Backend oder Frontend befinden erfolgt durch `if (rex::isBackend() == 1) {...`
 
 ## Moduleingabe
-      <div class="form-horizontal">
-          <div class="form-group">
+    <div class="form-horizontal">
+        <div class="form-group">
               <label class="col-sm-2 control-label">Artikelauswahl:</label>
               <div class="col-sm-8">
                  REX_LINK[id=1 widget=1]
               </div>
           </div>
+      </div>
 
 ## Modulausgabe
 
-      <div class="included">
-      <?php
-      // Prüfen ob der aktuelle Artikel mit sich selbst verlinkt ist
-      if ("REX_ARTICLE_ID" != "REX_LINK[id=1]" && "REX_LINK[id=1]"!="" ) {
-                 
-              // Artikeldatensatz ermitteln
-              $art = rex_article::get('REX_LINK[id=1]'); 
-      
-              // Artikelinhalt auslesen inkl. aktuelle Sprache    
-              $article = new rex_article_content($art->getId(), $art->getClang());
-              
-              //Weitere Informationen auslesen z.B. Titel, Beschreibung
-              $art_title = $art->getName();
-             
-             // Weitere Daten der MetaInfos können wie folgt ausgelesen werden 
-           // z.B. Beschreibung
-             // $art_description =  $art->getValue('art_description');    
-        
-         // Hinweisbox für's Backend
-              if (rex::isBackend() == 1) 
-              {
-                  echo '<div class="alert alert-info">
-                   <a href="
-                   '.rex_url::backendPage('content/edit',
-                   ['mode' => 'edit',
-                   'clang' => rex_clang::getCurrentId(),
-                   'article_id' => 'REX_LINK[id=1]']).'">
-                   <i class="fa fa-pencil-square-o" aria-hidden="true"></i> Eingebundener Artikel: '.$art->getName().'</a>
-                  </div>';           
-              } // Ende Hinweisbox
-          
-              // Artikel ausgeben, für andere Ctypes Zahl ändern. Für den gesamten Artikel, die 1 entfernen
-              
-              echo $article->getArticle(1);
-          
-      }
-      
-      else { // Was soll passieren wenn der Artikel nicht eingebunden werden kann?
-      }
-      ?>
-      </div>
+    <?php 
+
+    // Prüfen ob der aktuelle Artikel mit sich selbst verlinkt ist
+    if ("REX_ARTICLE_ID" != "REX_LINK[id=1]" && "REX_LINK[id=1]"!="" ) {
+    
+    	// Artikeldatensatz ermitteln
+    	$art = rex_article::get('REX_LINK[id=1]'); 
+    
+    	// Artikelinhalt auslesen inkl. aktuelle Sprache    
+    	$article = new rex_article_content($art->getId(), $art->getClang());
+    
+    	//Weitere Informationen auslesen z.B. Titel, Beschreibung
+    	$art_title = $art->getName();
+    
+    	// Weitere Daten der MetaInfos können wie folgt ausgelesen werden 
+    
+    		// z.B. Beschreibung
+    		// $art_description =  $art->getValue('art_description');
+    }
+        		
+    
+    // Ausgabe Backend
+    if (rex::isBackend() == 1) {
+	
+	// Es handelt sich nicht um denselben Artikel
+	if ("REX_ARTICLE_ID" != "REX_LINK[id=1]" && "REX_LINK[id=1]"!="" ) {
+		
+		echo '<div class="alert alert-info">
+			<a href="
+			'.rex_url::backendPage('content/edit',
+								   ['mode' => 'edit',
+									'clang' => rex_clang::getCurrentId(),
+									'article_id' => 'REX_LINK[id=1]']).'">
+			<i class="fa fa-pencil-square-o" aria-hidden="true"></i> Eingebundener Artikel: '.$art->getName().'</a>
+			</div>';           		
+		
+	}
+	
+	// Es handelt sich um denselben Artikel
+	else { 
+		// Was soll passieren wenn der Artikel nicht eingebunden werden kann?
+		echo "Bitte prüfe den ausgewählten Artikel. Du scheinst auf diesen Artikel hier zu verlinken.";
+	  }	
+    	
+    }
+    
+    
+    // Ausgabe Frontend
+    else {
+	
+	// Es handelt sich nicht um denselben Artikel
+	if ("REX_ARTICLE_ID" != "REX_LINK[id=1]" && "REX_LINK[id=1]"!="" ) {
+		
+    	// Artikel ausgeben, für andere ctypes Zahl ändern. Für den gesamten Artikel, die 1 entfernen         
+        echo $article->getArticle();		
+		
+	}		
+	
+    }
+
+    ?>


### PR DESCRIPTION
Hallo Thomas,

vielen Dank für das Mini-Beispiel "Artikel einbinden". Sehr sehr praktisch und pfiffig umgesetzt!

Hier mein Vorschlag für das Mini-Beispiel "Artikel einbinden". 

Für die die Modul-Ausgabe:
Mein Ziel war, Backend- und Frontend-Ausgabe klarer voneinander zu trennen. (Auch wenn das ein paar Zeilen mehr code bedeutet).
Mir erschloss sich der Nutzen des div mit der class "included" nicht, daher ersatzlos rausgenommen.

Für die Modul-Eingabe:
Es fehlte ein schließender div.

Was hältst Du davon?

Viele Grüße,
Franziska


PS: Ich übe noch, was das markdown von github und pull requests angeht. Daher sieht es so aus, als hätte ich unten code bei der Modul-Eingabe (Zeile 12 + 13) gelöscht, ich hatte jedoch einfach nur das markdown falsch. Sorry. 