### PR TITLE
Zwei neue Tricks für YForm

### DIFF
--- a/_docs/addons/yform/form_elements_attribute_php.md
+++ b/_docs/addons/yform/form_elements_attribute_php.md
@@ -1,0 +1,19 @@
+---
+title: "YForm Formulare: Attribute für Input-Elemente in PHP-Schreibweise"
+authors: [danspringer]
+prio:
+---
+
+
+# YForm Formulare: Attribute für Input-Elemente in PHP-Schreibweise
+
+Um einen eigenen Submit-Button per PHP in yForm-Formularen anzuzeigen, muss man in den Formular-Parametern den automatisch generierten Submit-Button unterdrücken und kann anschließend per HTML-Element einen eigenen Button hinzufügen. 
+
+## Attribute an YForm-Element anfügen
+
+Hinweis: Die ursprünglich von YForm erzeugte Klasse 'form-control' werden z.B. bei Nutzung eigener CSS-Klassen durch die eigenen ersetzt.
+
+```php
+$yform->setValueField('textarea', array("message","label", '#attributes:{"placeholder":"Geben Sie eine Nachricht ein", "class":"css-klassenname", "id":"form-id"}'));
+```
+

--- a/_docs/addons/yform/own_submit_button_php.md
+++ b/_docs/addons/yform/own_submit_button_php.md
@@ -1,0 +1,21 @@
+---
+title: "YForm Formulare: Eigener Submit-Button mit PHP"
+authors: [danspringer]
+prio:
+---
+
+
+# YForm Formulare: Eigener Submit-Button mit PHP
+
+Um einen eigenen Submit-Button per PHP in yForm-Formularen anzuzeigen, muss man in den Formular-Parametern den automatisch generierten Submit-Button unterdrücken und kann anschließend per HTML-Element einen eigenen BUtton hinzufügen. 
+
+## Automatisch generierten Submit-Button ausschalten
+```php
+$yform->setObjectparams('submit_btn_show',false); 
+```
+
+## Eigenen Button per HTML-Value einfügen
+Egal wohin, muss nur erreichbar sein von `rex_extension::register`.
+```php
+$yform->setValueField('html', array("html","HTML",'<button type="submit" class="btn btn-info btn-block">Jetzt absenden</button>'));
+```

--- a/_docs/addons/yform/own_submit_button_php.md
+++ b/_docs/addons/yform/own_submit_button_php.md
@@ -15,7 +15,6 @@ $yform->setObjectparams('submit_btn_show',false);
 ```
 
 ## Eigenen Button per HTML-Value einfügen
-Egal wohin, muss nur erreichbar sein von `rex_extension::register`.
 ```php
 $yform->setValueField('html', array("html","HTML",'<button type="submit" class="btn btn-info btn-block">Jetzt absenden</button>'));
 ```


### PR DESCRIPTION
- YForm Formulare: Attribute für Input-Elemente in PHP-Schreibweise
- YForm Formulare: Eigener Submit-Button mit PHP