### PR TITLE
Update protected_files.md

### DIFF
--- a/_docs/addons/ycom/protected_files.md
+++ b/_docs/addons/ycom/protected_files.md
@@ -77,7 +77,7 @@ rex_extension::register('FE_OUTPUT', function () {
 });
 
 // check fileperm fuer media manager dateiaufrufe
-if (!rex::isBackend())
+if (!rex_backend_login::hasSession())
 {
     $filename = rex_get('rex_media_file', 'string');
     if ($filename && file_exists(rex_path::media($filename)))


### PR DESCRIPTION
if (!rex::isBackend()) sollte nicht verwendet werden, ansonsten lassen sich auch geschützte Bilder über
www.meinedomain.de/redaxo/index.php?rex_media_type=MediaTypeName&amp;rex_media_file=MediaFileName
aufrufen, auch, wenn man nicht im Backend eingeloggt ist (rex::isBackend() prüft anscheinend nur, ob /redaxo in der URL steht).
Stattdessen rex_backend_login::hasSession() ... dann funktioniert es sehr gut!
if (!rex_backend_login::hasSession())