### PR TITLE
Redaxo 4 Passwörter migrieren

### DIFF
--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -47,29 +47,31 @@ Der Nachfolger von **XForm** heißt in REDAXO 5 **YForm**. Die Tabellen und Eins
 
 Als Lösung und Ersatz des Multiuploader-AddOn stehen die AddOns ***uploader*** und **multiuploader** zur Verfügung. 
 
-### Redaxo 4 Passwörter migrieren
-**WICHTIG: rex_user Tabelle zu Beginn sichern!** Redaxo 4 Passwörter können mit folgendem Snippet Redaxo 5 kompatibel gemacht werden. 
+### Benutzer Passwörter in REDAXO 5 importieren
+**WICHTIG: rex_user / rex_xcom_user Tabelle zu Beginn sichern!** 
+**WICHTIG: Alte Passwortverschlüsselung auf Typ prüfen**
+Passwörter aus REDAXO 4 können mit folgendem Snippet REDAXO 5 kompatibel gemacht werden.
 
 #### To-Do: Tabelle
-Folgende Schritte sind notwendig um alte Redaxo 4 Passwörter auch in Redaxo 5 verwenden zu können.
+Folgende Schritte sind notwendig um alte Passwörter aus REDAXO 4 auch in REDAXO 5 verwenden zu können.
 
-- Zunächst wird der Export der `rex_user` Datenbank aus der Redaxo 4 Instanz benötigt. Der könnte beispielsweise so aussehen:
+- Zunächst wird der Export der `rex_user`, bzw. `rex_xcom_user`, Datenbank aus der REDAXO 4 Instanz benötigt. Der könnte beispielsweise so aussehen:
 
 ```mysql
 INSERT INTO `rex_user` (`user_id`, `name`, `description`, `login`, `psw`, `status`, `rights`, `login_tries`, `createuser`, `updateuser`, `createdate`, `updatedate`, `lasttrydate`, `session_id`) VALUES
-(2, 'Redaxo 4 Redakteur', '', 'redaktion', 'f616d7c4c54614b51f5d0bfa877e1a3ae63d31e3', '1', '#admin[]#clang[0]#', 0, 'admin', '', 1574436072, 0, 0, '');
+(2, 'REDAXO 4 Redakteur', '', 'redaktion', 'f616d7c4c54614b51f5d0bfa877e1a3ae63d31e3', '1', '#admin[]#clang[0]#', 0, 'admin', '', 1574436072, 0, 0, '');
 ```
 
-  - Das Feld `rights` kann entfernt werden. Redaxo 5 verwendet nun Rollen um die Rechte der Nutzer zu verwalten.
-  - Das Feld `user_id` heißt in Redaxo 5 nun `id` und ist unique. Sollte eine Id bereits vorhanden sein, wird der Insert nicht klappen. Entweder wird die Id selbst vergeben oder entfernt.
-  - Das Feld `psw` heißt in Redaxo 5 nun `password`
+  - Das Feld `rights` kann entfernt werden. REDAXO 5 verwendet nun Rollen um die Rechte der Nutzer zu verwalten.
+  - Das Feld `user_id` heißt in REDAXO 5 nun `id` und ist unique. Sollte eine Id bereits vorhanden sein, wird der Insert nicht klappen. Entweder wird die Id selbst vergeben oder entfernt.
+  - Das Feld `psw` heißt in REDAXO 5 nun `password`
   - Die Felder `createdate`, `updatedate`, `lasttrydate` sind nun `datetime` Felder und müssen von Unix Timestamp umgewandelt werden.
   - `session_id` sollte entfernt werden.
   
 Beispiel Insert:
 ```mysql
 INSERT INTO `rex_user` (`id`, `name`, `description`, `login`, `password`, `status`, `login_tries`, `createuser`, `updateuser`, `createdate`, `updatedate`, `lasttrydate`) VALUES
-(2, 'Redaxo 4 Redakteur', '', 'redaktion', 'f616d7c4c54614b51f5d0bfa877e1a3ae63d31e3', '1', 0, 'admin', '', FROM_UNIXTIME(1574436072), 0, 0);
+(2, 'REDAXO 4 Redakteur', '', 'redaktion', 'f616d7c4c54614b51f5d0bfa877e1a3ae63d31e3', '1', 0, 'admin', '', FROM_UNIXTIME(1574436072), 0, 0);
 ```
 Beispiel minimaler Insert:
 ```mysql
@@ -77,10 +79,10 @@ INSERT INTO `rex_user` (`login`, `password`) VALUES
 ('redaktion', 'f616d7c4c54614b51f5d0bfa877e1a3ae63d31e3');
 ```
 
-Der Insert kann jetzt in die Redaxo 5 Tabelle eingespielt werden. Die Id's der neuen Datensätze sollte man sich merken, da sie später für das Update der Passwörter gebraucht werden.
+Der Insert kann jetzt in die REDAXO 5 Tabelle eingespielt werden. Die Ids der neuen Datensätze sollte man sich merken, da sie später für das Update der Passwörter gebraucht werden.
 
 #### To-Do: Template / Module
-- `$users` muss in der setWhere() Funktion beschränkt werden! Es dürfen nur die Redaxo 4 Accounts selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
+- `$users` muss in der setWhere() Funktion beschränkt werden! Es dürfen nur die Ids mit REDAXO 4 Passwörtern selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
 - Das Snippet darf nur einmal aufgerufen werden, innerhalb eines Modules oder Templates.
 
 
@@ -89,19 +91,20 @@ Der Insert kann jetzt in die Redaxo 5 Tabelle eingespielt werden. Die Id's der n
 $users = rex_sql::factory()
     ->setDebug(true)
     ->setTable(rex::getTable('user'))
-     //Redaxo 4 Redakteur aus dem Beispiel wurde mit der Id 2 in die Tabelle rex_user importiert
-     //natürlich sind auch mehrere Datensätze gleichzeitig selektierbar, es dürfen allerdings nur die importierten Redaxo 4 User sein!
+     //REDAXO 4 Redakteur aus dem Beispiel wurde mit der Id 2 in die Tabelle rex_user importiert
+     //natürlich sind auch mehrere Datensätze gleichzeitig selektierbar, es dürfen allerdings nur die importierten REDAXO 4 User sein!
     ->setWhere(['id' => 2])
     ->select();
 ```
-Sobald `$users` alle Redaxo 4 Redakteure enthält, kann folgendes Script in einem Modul oder Template **einmalig** ausgeführt werden. Alte Redaxo 4 Passwörter werden dadurch umgewandelt-
+Sobald `$users` alle REDAXO 4 Redakteure enthält, kann folgendes Script in einem Modul oder Template **einmalig** ausgeführt werden. Alte Passwörter aus REDAXO 4 werden dadurch umgewandelt. Sollten die Passwörter nicht verschlüsselt vorliegen, muss mittels der Umstellung der Variable `$isPreHashed = false;` eine Vorverschlüsselung vorgenommen werden.
 ```php
+$isPreHashed = true;
 foreach ($users as $user) {
     $sql = rex_sql::factory()
         ->setDebug(true)
         ->setTable(rex::getTable('user'))
         ->setWhere(['login' => $user->getValue('login')])
-        ->setValue('password', rex_login::passwordHash($user->getValue('password'), true))
+        ->setValue('password', rex_login::passwordHash($user->getValue('password'), $isPreHashed))
         ->update();
 }
 

--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -53,7 +53,7 @@ Als Lösung und Ersatz des Multiuploader-AddOn stehen die AddOns ***uploader*** 
 
 Passwörter aus REDAXO 4 können mit folgendem Snippet REDAXO 5 kompatibel gemacht werden.
 
-#### To-Do: Tabelle
+#### Schritt 1: Tabelle
 Folgende Schritte sind notwendig um alte Passwörter aus REDAXO 4 auch in REDAXO 5 verwenden zu können.
 
 - Zunächst wird der Export der `rex_user`, bzw. `rex_xcom_user`, Datenbank aus der REDAXO 4 Instanz benötigt. Der könnte beispielsweise so aussehen:

--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -82,7 +82,7 @@ INSERT INTO `rex_user` (`login`, `password`) VALUES
 
 Der Insert kann jetzt in die REDAXO 5 Tabelle eingespielt werden. Die Ids der neuen Datensätze sollte man sich merken, da sie später für das Update der Passwörter gebraucht werden.
 
-#### To-Do: Template / Module
+#### Schritt 2: Template / Module
 - `$users` **muss** in der setWhere() Funktion beschränkt werden! Es dürfen nur die Ids mit REDAXO 4 Passwörtern selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
 - Das Snippet darf nur einmal aufgerufen werden, innerhalb eines Modules oder Templates.
 - Sollten bereits gehashte als auch ungehashte Passwörter vorlieren, empfiehlt es sich `$users` bereits entsprechend zu selektieren für den nächsten Schritt.

--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -46,3 +46,32 @@ Der Nachfolger von **XForm** heißt in REDAXO 5 **YForm**. Die Tabellen und Eins
 ### Multiuploads
 
 Als Lösung und Ersatz des Multiuploader-AddOn stehen die AddOns ***uploader*** und **multiuploader** zur Verfügung. 
+
+### Redaxo 4 Passwörter migrieren
+**WICHTIG: rex_user Tabelle zu Beginn sichern!** Redaxo 4 Passwörter können mit folgendem Snippet Redaxo 5 kompatibel gemacht werden. 
+
+Folgende Schritte sind notwendig um alte Redaxo 4 Passwörter auch in Redaxo 5 verwenden zu können.
+
+- Manueller Import in `rex_user` gewünschter User Accounts
+- `$users` muss in der setWhere() Funktion beschränkt werden! Es dürfen nur die Redaxo 4 Accounts selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
+- Das Snippet darf nur einmal aufgerufen werden, innerhalb eines Modules oder Templates.
+
+
+```php
+<?php
+$users = rex_sql::factory()
+    ->setDebug(true)
+    ->setTable(rex::getTable('user'))
+    // ->setWhere() //nur redaxo 4 accounts
+    ->select();
+
+foreach ($users as $user) {
+    $sql = rex_sql::factory()
+        ->setDebug(true)
+        ->setTable(rex::getTable('user'))
+        ->setWhere(['login' => $user->getValue('login')])
+        ->setValue('password', rex_login::passwordHash($user->getValue('password'), true))
+        ->update();
+}
+?>
+```

--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -48,8 +48,8 @@ Der Nachfolger von **XForm** heißt in REDAXO 5 **YForm**. Die Tabellen und Eins
 Als Lösung und Ersatz des Multiuploader-AddOn stehen die AddOns ***uploader*** und **multiuploader** zur Verfügung. 
 
 ### Benutzer Passwörter in REDAXO 5 importieren
-**WICHTIG: rex_user / rex_xcom_user Tabelle zu Beginn sichern!** 
-**WICHTIG: Alte Passwortverschlüsselung auf Typ prüfen**
+- **WICHTIG: rex_user / rex_xcom_user Tabelle zu Beginn sichern!** 
+- **WICHTIG: Alte Passwortverschlüsselung auf Typ prüfen**
 Passwörter aus REDAXO 4 können mit folgendem Snippet REDAXO 5 kompatibel gemacht werden.
 
 #### To-Do: Tabelle
@@ -82,8 +82,9 @@ INSERT INTO `rex_user` (`login`, `password`) VALUES
 Der Insert kann jetzt in die REDAXO 5 Tabelle eingespielt werden. Die Ids der neuen Datensätze sollte man sich merken, da sie später für das Update der Passwörter gebraucht werden.
 
 #### To-Do: Template / Module
-- `$users` muss in der setWhere() Funktion beschränkt werden! Es dürfen nur die Ids mit REDAXO 4 Passwörtern selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
+- `$users` **muss** in der setWhere() Funktion beschränkt werden! Es dürfen nur die Ids mit REDAXO 4 Passwörtern selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
 - Das Snippet darf nur einmal aufgerufen werden, innerhalb eines Modules oder Templates.
+- Sollten bereits gehashte als auch ungehashte Passwörter vorlieren, empfiehlt es sich `$users` bereits entsprechend zu selektieren für den nächsten Schritt.
 
 
 ```php
@@ -96,8 +97,9 @@ $users = rex_sql::factory()
     ->setWhere(['id' => 2])
     ->select();
 ```
-Sobald `$users` alle REDAXO 4 Redakteure enthält, kann folgendes Script in einem Modul oder Template **einmalig** ausgeführt werden. Alte Passwörter aus REDAXO 4 werden dadurch umgewandelt. Sollten die Passwörter nicht verschlüsselt vorliegen, muss mittels der Umstellung der Variable `$isPreHashed = false;` eine Vorverschlüsselung vorgenommen werden.
+Sobald `$users` alle zu migrierenden REDAXO 4 Accounts enthält, kann folgendes Script in einem Modul oder Template **einmalig** ausgeführt werden. Alte Passwörter aus REDAXO 4 werden dadurch umgewandelt. Sollten die Passwörter nicht verschlüsselt vorliegen, muss mittels der Umstellung der Variable `$isPreHashed = false;` eine Vorverschlüsselung vorgenommen werden.
 ```php
+
 $isPreHashed = true;
 foreach ($users as $user) {
     $sql = rex_sql::factory()

--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -50,6 +50,7 @@ Als Lösung und Ersatz des Multiuploader-AddOn stehen die AddOns ***uploader*** 
 ### Benutzer Passwörter in REDAXO 5 importieren
 - **WICHTIG: rex_user / rex_xcom_user Tabelle zu Beginn sichern!** 
 - **WICHTIG: Alte Passwortverschlüsselung auf Typ prüfen**
+
 Passwörter aus REDAXO 4 können mit folgendem Snippet REDAXO 5 kompatibel gemacht werden.
 
 #### To-Do: Tabelle

--- a/_docs/howto/redaxo_4_5_upgrade.md
+++ b/_docs/howto/redaxo_4_5_upgrade.md
@@ -52,7 +52,7 @@ Als Lösung und Ersatz des Multiuploader-AddOn stehen die AddOns ***uploader*** 
 
 Folgende Schritte sind notwendig um alte Redaxo 4 Passwörter auch in Redaxo 5 verwenden zu können.
 
-- Manueller Import in `rex_user` gewünschter User Accounts
+- Manueller Import der Redaxo 4 Accounts in `rex_user` der Redaxo 5 Instanz. Beachten: die Tabellenstruktur hat sich geändert!
 - `$users` muss in der setWhere() Funktion beschränkt werden! Es dürfen nur die Redaxo 4 Accounts selektiert werden, andernfalls werden bereits korrekte Passwörter erneut gehasht und funktionieren nicht mehr.
 - Das Snippet darf nur einmal aufgerufen werden, innerhalb eines Modules oder Templates.
 


### PR DESCRIPTION
Ein kleines Snippet um Redaxo 4 User auch in 5 weiterverwenden zu können.