### PR TITLE
Trick link hinzugefügt

### DIFF
--- a/_docs/diverses/performance.md
+++ b/_docs/diverses/performance.md
@@ -60,7 +60,7 @@ xdebug
 ## Welche Möglichkeiten zur Verbesserung bietet REDAXO?
 
 an dieser Stelle sei auf diesen trick hingewiesen:
-[Performance prüfen](https://github.com/FriendsOfREDAXO/tricks/blob/master/_docs/snippets/performance_pruefen.md)
+[Performance prüfen](https://friendsofredaxo.github.io/tricks/snippets/performance_pruefen)
 
 cache
 


### PR DESCRIPTION
Habe mich gewundert wieso die GitHub Url zum Trick verlinkt war, Und nicht die Url zum Trick auf der Seite selbst. Aber ich wollte trotzdem mal einen PR Erstellen, nur auf nummer sicher zu gehen :) !.