### PR TITLE
YForm-Sätze duplizieren: aktualisiert und gekürzt

### DIFF
--- a/_docs/addons/yform/add_clone.md
+++ b/_docs/addons/yform/add_clone.md
@@ -1,6 +1,6 @@
 ---
 title: Datensätze duplizieren ("Add" mit Vorbelegung)
-authors: [christophboecker]
+authors: [christophboecker,xong]
 prio:
 ---
 


### PR DESCRIPTION
Im Hinblick auf #309 zur Vermeidung von doppelten Tricks überarbeitet und verkürzt und eine Trait-Variante (@xong) aufgenommen.

closes #309 