### PR TITLE
YOrm Docs verlinken, wo YOrm erwähnt wird

### DIFF
--- a/_docs/addons/forcal/config.md
+++ b/_docs/addons/forcal/config.md
@@ -31,7 +31,7 @@ forcal kann...
 - mit beliebigen Datenfeldern in den bestehenden Tabellen erweitert werden
 - um weitere Tabellen ergänzt werden
 - das Backend kann nach eigenen Bedürfnissen umgestaltet werden
-- die Ausgabe kann über yorm Objekte und Fragmente gelöst werden
+- die Ausgabe kann über [Yorm-Objekte](https://github.com/yakamara/redaxo_yform/blob/master/docs/04_yorm.md) und Fragmente gelöst werden
 
 Das soll hier an einem Beispiel gezeigt werden.
 

--- a/_docs/addons/url/lange_listen_schnell_ausgeben.md
+++ b/_docs/addons/url/lange_listen_schnell_ausgeben.md
@@ -38,7 +38,7 @@ if (count($profile) == 1) {
 }
 ```
 
-Dieses Array können wir dann direkt in einer Ausgabe verwenden. Hier wurde die Produktliste als yorm Objekt abgeholt
+Dieses Array können wir dann direkt in einer Ausgabe verwenden. Hier wurde die Produktliste als [YOrm-Objekt](https://github.com/yakamara/redaxo_yform/blob/master/docs/04_yorm.md) abgeholt
 
 ```php
 <ul>

--- a/_docs/addons/yform/rss.md
+++ b/_docs/addons/yform/rss.md
@@ -4,7 +4,7 @@ authors: [skerbis]
 prio:
 ---
 
-# RSS mit YORM und [SimpleXML](https://www.php.net/manual/de/book.simplexml.php)
+# RSS mit [YOrm](https://github.com/yakamara/redaxo_yform/blob/master/docs/04_yorm.md) und [SimpleXML](https://www.php.net/manual/de/book.simplexml.php)
 
 
 

--- a/_docs/addons/yform/yf4-action-dropdown.md
+++ b/_docs/addons/yform/yf4-action-dropdown.md
@@ -88,7 +88,7 @@ wird der Text des delete-Buttons in einer statischen Variablen der Datensatzklas
 zeitlich danach aufgerufene EP YFORM_DATA_LIST greift darauf zu und entfernt - wenn der Datensatz
 zum Löschen gesperrt ist - den Text inkl. umgebendem `<li></li>` aus dem HTML.
 
-(Achtung: Werbung für YOrm) Das Beispiel setzt auf einer eigenen YOrm-Datensatzklasse (`mytable`) auf,
+Das Beispiel setzt auf einer eigenen [YOrm-Datensatzklasse](https://github.com/yakamara/redaxo_yform/blob/master/docs/04_yorm.md) (`mytable`) auf,
 die auf `rex_yform_manager_dataset` basiert.
 
 Damit YForm die private Dataset-Klasse statt der Default-Klasse verwendet, muss sie dem System

--- a/_docs/snippets/queries.md
+++ b/_docs/snippets/queries.md
@@ -107,7 +107,7 @@ public function getNext()
 <a name="paginierung-prio"></a>
 ## Blättern auf Prio basierende Datensätze zu erstellen
 
-Die Methoden basieren auf Yorm und gehören in eine Class wie zum Beispiel
+Die Methoden basieren auf [YOrm](https://github.com/yakamara/redaxo_yform/blob/master/docs/04_yorm.md) und gehören in eine Class wie zum Beispiel
 
 ```php
 class Item extends rex_yform_manager_dataset


### PR DESCRIPTION
Im Moment wird beim Googlen nach YOrm das alte Docs-Repo favorisiert. Die Doku da ist jedoch veraltet - es gibt z.B. viel mehr Methoden inzwischen an den Objekten!

Mit der Verlinkung aus den Tricks heraus hoffe ich, die Platzierung der richtigen Doku zu begünstigen.

Generell könnten Begriffe wie "Fragmente" u.a. auch grundsätzlich mit der Doku querverlinkt werden, die Option halte ich mir mal offen für die Zukunft.